### PR TITLE
adding datetime adapter and converter

### DIFF
--- a/database/setup.py
+++ b/database/setup.py
@@ -58,8 +58,6 @@ class Database:
         self.__create_default_users()
 
     def __setup_tables(self):
-        self.cursor.execute("DROP TABLE Users")
-
         # Users Table
         self.cursor.execute(
             f"""
@@ -83,38 +81,51 @@ class Database:
                 date_of_birth DATETIME,
                 diagnosis TEXT,
                 clinician_id INTEGER,
-                FOREIGN KEY (user_id) REFERENCES Users(user_id),
-                FOREIGN KEY (clinician_id) REFERENCES Users(user_id) 
+                FOREIGN KEY (user_id) REFERENCES Users(user_id) ON DELETE CASCADE,
+                FOREIGN KEY (clinician_id) REFERENCES Users(user_id) ON DELETE SET NULL
             )
         """)
 
-        # Journal Table (Mood + Text)
-        # To simplify, I am thinking of storing the mood as a whole string (with colour and all)
-        # Nevertheless, we can change this to a FK to a Mood table or whatever we think is best
+        # Journal Table
         self.cursor.execute("""
             CREATE TABLE IF NOT EXISTS JournalEntries (
                 entry_id INTEGER PRIMARY KEY,
                 user_id INTEGER NOT NULL,
                 date DATETIME NOT NULL,
+                text TEXT,
+                FOREIGN KEY (user_id) REFERENCES Users(user_id) ON DELETE CASCADE
+            )
+        """)
+
+        # Mood Table (Mood + Text)
+        # To simplify, I am thinking of storing the mood as a whole string (with colour and all)
+        # Nevertheless, we can change this to a FK to a Mood table or whatever we think is best
+        self.cursor.execute("""
+            CREATE TABLE IF NOT EXISTS MoodEntries (
+                entry_id INTEGER PRIMARY KEY,
+                user_id INTEGER NOT NULL,
+                date DATETIME NOT NULL,
                 mood TEXT,
                 text TEXT,
-                FOREIGN KEY (user_id) REFERENCES Users(user_id)
+                FOREIGN KEY (user_id) REFERENCES Users(user_id) ON DELETE CASCADE
             )
         """)
 
         # Appointments Table
         # We can use is_completed to mark if the user actually attended the appointment
+        # If the clinician is deleted the appoitment still remains so we dont lose the
+        # notes for the user, but we can change this to CASCADE
         self.cursor.execute("""
             CREATE TABLE IF NOT EXISTS Appointments (
                 appointment_id INTEGER PRIMARY KEY,
                 user_id INTEGER NOT NULL,
-                clinician_id INTEGER NOT NULL,
+                clinician_id INTEGER,
                 date DATETIME NOT NULL,
                 is_confirmed BOOLEAN DEFAULT 0,
                 is_complete BOOLEAN DEFAULT 0,
                 notes TEXT NOT NULL,
-                FOREIGN KEY (user_id) REFERENCES Users(user_id),
-                FOREIGN KEY (clinician_id) REFERENCES Users(user_id) 
+                FOREIGN KEY (user_id) REFERENCES Users(user_id) ON DELETE CASCADE,
+                FOREIGN KEY (clinician_id) REFERENCES Users(user_id) ON DELETE SET NULL
             )
         """)
 

--- a/database/setup.py
+++ b/database/setup.py
@@ -31,9 +31,11 @@ def adapt_datetime_iso(val):
     """Adapt datetime.datetime to timezone-naive ISO 8601 date."""
     return val.isoformat()
 
+
 def convert_datetime(val):
     """Convert ISO 8601 datetime to datetime.datetime object."""
     return datetime.fromisoformat(val.decode())
+
 
 sqlite3.register_adapter(datetime, adapt_datetime_iso)
 sqlite3.register_converter("datetime", convert_datetime)
@@ -56,6 +58,8 @@ class Database:
         self.__create_default_users()
 
     def __setup_tables(self):
+        self.cursor.execute("DROP TABLE Users")
+
         # Users Table
         self.cursor.execute(
             f"""
@@ -76,7 +80,7 @@ class Database:
             CREATE TABLE IF NOT EXISTS Patients (
                 user_id INTEGER PRIMARY KEY,
                 emergency_email TEXT,
-                date_of_birth TEXT,
+                date_of_birth DATETIME,
                 diagnosis TEXT,
                 clinician_id INTEGER,
                 FOREIGN KEY (user_id) REFERENCES Users(user_id),
@@ -91,7 +95,7 @@ class Database:
             CREATE TABLE IF NOT EXISTS JournalEntries (
                 entry_id INTEGER PRIMARY KEY,
                 user_id INTEGER NOT NULL,
-                date TEXT NOT NULL,
+                date DATETIME NOT NULL,
                 mood TEXT,
                 text TEXT,
                 FOREIGN KEY (user_id) REFERENCES Users(user_id)
@@ -176,9 +180,9 @@ class Database:
             # For now, we are defining that patient1 is assigned to mhwp1 and the othet two are not assigned
             # This should allow us to test what happens when a patient is not assigned to a clinician
             patients = [
-                (2, "emergency1@gmail.com", "2000-01-01", None, 5),
-                (3, "emergency2@gmail.com", "1990-06-01", None, None),
-                (4, "emergency3@gmail.com", "1980-09-01", None, None),
+                (2, "emergency1@gmail.com", datetime(2000, 1, 1), None, 5),
+                (3, "emergency2@gmail.com", datetime(1990, 6, 1), None, None),
+                (4, "emergency3@gmail.com", datetime(1980, 9, 1), None, None),
             ]
             self.cursor.executemany(
                 "INSERT INTO Patients VALUES(?, ?, ?, ?, ?)", patients

--- a/database/setup.py
+++ b/database/setup.py
@@ -1,4 +1,5 @@
 import sqlite3
+from datetime import datetime
 
 roles = ("admin", "patient", "clinician")
 
@@ -25,6 +26,19 @@ def dict_factory(cursor: sqlite3.Cursor, row: sqlite3.Row):
         return row[0]
 
 
+# Functions copied from the sqlite3 documentation - allowing us to insert and retrieve dates as python datetimes
+def adapt_datetime_iso(val):
+    """Adapt datetime.datetime to timezone-naive ISO 8601 date."""
+    return val.isoformat()
+
+def convert_datetime(val):
+    """Convert ISO 8601 datetime to datetime.datetime object."""
+    return datetime.fromisoformat(val.decode())
+
+sqlite3.register_adapter(datetime, adapt_datetime_iso)
+sqlite3.register_converter("datetime", convert_datetime)
+
+
 class Database:
     connection: sqlite3.Connection
     cursor: sqlite3.Cursor
@@ -32,7 +46,9 @@ class Database:
     def __init__(self):
         # Connect to the database and make the connection and cursor available
         # TODO: evaluate if we want to put a try/except block here
-        self.connection = sqlite3.connect("breeze.db")
+        self.connection = sqlite3.connect(
+            "breeze.db", detect_types=sqlite3.PARSE_DECLTYPES | sqlite3.PARSE_COLNAMES
+        )
         self.connection.row_factory = dict_factory
         self.cursor = self.connection.cursor()
         self.connection.execute("PRAGMA foreign_keys = ON")
@@ -89,7 +105,7 @@ class Database:
                 appointment_id INTEGER PRIMARY KEY,
                 user_id INTEGER NOT NULL,
                 clinician_id INTEGER NOT NULL,
-                date TEXT NOT NULL,
+                date DATETIME NOT NULL,
                 is_confirmed BOOLEAN DEFAULT 0,
                 is_complete BOOLEAN DEFAULT 0,
                 notes TEXT NOT NULL,
@@ -152,7 +168,9 @@ class Database:
                     True,
                 ),
             ]
-            self.cursor.executemany("INSERT INTO Users VALUES(?, ?, ?, ?, ?, ?, ?)", users)
+            self.cursor.executemany(
+                "INSERT INTO Users VALUES(?, ?, ?, ?, ?, ?, ?)", users
+            )
 
             # NOTE: We need to define the default state we want for the app
             # For now, we are defining that patient1 is assigned to mhwp1 and the othet two are not assigned
@@ -162,7 +180,24 @@ class Database:
                 (3, "emergency2@gmail.com", "1990-06-01", None, None),
                 (4, "emergency3@gmail.com", "1980-09-01", None, None),
             ]
-            self.cursor.executemany("INSERT INTO Patients VALUES(?, ?, ?, ?, ?)", patients)
+            self.cursor.executemany(
+                "INSERT INTO Patients VALUES(?, ?, ?, ?, ?)", patients
+            )
+
+            appointments = [
+                (
+                    1,
+                    2,
+                    5,
+                    datetime(2024, 11, 20, hour=12, minute=0),
+                    False,
+                    False,
+                    "detailed notes",
+                )
+            ]
+            self.cursor.executemany(
+                "INSERT INTO Appointments VALUES(?, ?, ?, ?, ?, ?, ?)", appointments
+            )
 
             self.connection.commit()
 


### PR DESCRIPTION
Adding this as a suggestion which might make dealing with dates easier for us?
Took it from the sqlite3 documentation - it just defines converters which mean we can directly insert python datetimes into the query, and can also retrieve dates as datetimes.
Note that we have to define the type as 'DATETIME' or 'DATE' on the table - I haven't changed this on all of them as I wanted to check if we all agree on this first.